### PR TITLE
Download the portaudio tarball from github.com

### DIFF
--- a/portaudio/all/conandata.yml
+++ b/portaudio/all/conandata.yml
@@ -1,7 +1,7 @@
 sources:
   "19.7.0":
-    url: "http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz"
-    sha256: "47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def"
+    url: "https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz"
+    sha256: "5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0"
 patches:
   "19.7.0":
     - patch_file: "patches/19.7.0/wasapi-loopback.patch"

--- a/portaudio/all/conanfile.py
+++ b/portaudio/all/conanfile.py
@@ -73,7 +73,7 @@ class ConanRecipe(ConanFile):
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])
-        os.rename("portaudio", self.sources_folder)
+        os.rename("portaudio-19.7.0", self.sources_folder)
 
         if "patches" in self.conan_data:
             for p in self.conan_data["patches"][self.version]:


### PR DESCRIPTION
This is a potential solution to the fact that portaudio.com is offline.
More details can be found in
https://github.com/audacity/audacity/issues/1523

It may even be desirable in the long run as github has https in contrast
to the http being used by portaudio.com