### PR TITLE
Enable rapidjson to be built on Windows on Arm64 natively

### DIFF
--- a/recipes/rapidjson/all/conandata.yml
+++ b/recipes/rapidjson/all/conandata.yml
@@ -13,3 +13,6 @@ sources:
   cci.20200410:
     url: https://github.com/Tencent/rapidjson/archive/8f4c021fa2f1e001d2376095928fc0532adf2ae6.zip
     sha256: e6fc99c7df7f29995838a764dd68df87b71db360f7727ace467b21b82c85efda
+patches:
+  1.1.0:
+    - patch_file: patches/win_arm64.patch

--- a/recipes/rapidjson/all/conanfile.py
+++ b/recipes/rapidjson/all/conanfile.py
@@ -1,5 +1,5 @@
 from conan import ConanFile
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, apply_conandata_patches, export_conandata_patches
 from conan.tools.layout import basic_layout
 import os
 
@@ -20,10 +20,16 @@ class RapidjsonConan(ConanFile):
         basic_layout(self, src_folder='src')
         self.folders.build = 'build'
         self.folders.generators = 'build/conan'
+        if self.settings.os == 'Windows' and self.settings.arch == 'armv8':
+            os.environ["CXXFLAGS"] = '-DRAPIDJSON_ENDIAN=RAPIDJSON_LITTLEENDIAN'
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True,
                     destination=self.source_folder)
+        apply_conandata_patches(self)
+
+    def export_sources(self):
+        export_conandata_patches(self)
 
     def package(self):
         copy(self, pattern="license.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))

--- a/recipes/rapidjson/all/patches/win_arm64.patch
+++ b/recipes/rapidjson/all/patches/win_arm64.patch
@@ -1,0 +1,12 @@
+--- a/include/rapidjson/rapidjson.h
++++ b/include/rapidjson/rapidjson.h
+@@ -236,7 +236,7 @@
+ #    define RAPIDJSON_ENDIAN RAPIDJSON_BIGENDIAN
+ #  elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) || defined(_M_IX86) || defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) || defined(__bfin__)
+ #    define RAPIDJSON_ENDIAN RAPIDJSON_LITTLEENDIAN
+-#  elif defined(_MSC_VER) && defined(_M_ARM)
++#  elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+ #    define RAPIDJSON_ENDIAN RAPIDJSON_LITTLEENDIAN
+ #  elif defined(RAPIDJSON_DOXYGEN_RUNNING)
+ #    define RAPIDJSON_ENDIAN
+


### PR DESCRIPTION
Allow _M_ARM64 for rapidjson and build it with little endian support.